### PR TITLE
Nissix plugin scope-packages on wkit

### DIFF
--- a/generated-example/index.js
+++ b/generated-example/index.js
@@ -1,5 +1,5 @@
 const path = require('path');
-const bootstrap = require('wix-bootstrap-ng');
+const bootstrap = require('@wix/wix-bootstrap-ng');
 
 const rootDir = process.env.SRC_PATH || './dist/src';
 const getPath = filename => path.join(rootDir, filename);

--- a/generated-example/package.json
+++ b/generated-example/package.json
@@ -25,19 +25,19 @@
     "react": "15.6.1",
     "react-dom": "15.6.1",
     "react-i18next": "~4.6.0",
-    "wix-axios-config": "latest",
-    "wix-bootstrap-ng": "latest",
-    "wix-express-csrf": "latest",
-    "wix-express-require-https": "latest",
-    "wix-run-mode": "latest",
+    "@wix/wix-axios-config": "latest",
+    "@wix/wix-bootstrap-ng": "latest",
+    "@wix/wix-express-csrf": "latest",
+    "@wix/wix-express-require-https": "latest",
+    "@wix/wix-run-mode": "latest",
     "regenerator-runtime": "^0.11.0"
   },
   "devDependencies": {
     "react-test-renderer": "~15.6.0",
     "enzyme": "~2.9.0",
     "husky": "~0.14.0",
-    "wix-bootstrap-testkit": "latest",
-    "wix-config-emitter": "latest"
+    "@wix/wix-bootstrap-testkit": "latest",
+    "@wix/wix-config-emitter": "latest"
   },
   "yoshi": {
     "externals": {

--- a/generated-example/src/client.js
+++ b/generated-example/src/client.js
@@ -3,7 +3,7 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import { I18nextProvider } from 'react-i18next';
 import axios from 'axios';
-import { wixAxiosConfig } from 'wix-axios-config';
+import { wixAxiosConfig } from '@wix/wix-axios-config';
 import i18n from './i18n';
 import App from './components/App';
 

--- a/generated-example/src/server.js
+++ b/generated-example/src/server.js
@@ -1,9 +1,9 @@
 import 'regenerator-runtime/runtime';
 import { readFileSync } from 'fs';
-import wixRunMode from 'wix-run-mode';
+import wixRunMode from '@wix/wix-run-mode';
 import ejs from 'ejs';
-import wixExpressCsrf from 'wix-express-csrf';
-import wixExpressRequireHttps from 'wix-express-require-https';
+import wixExpressCsrf from '@wix/wix-express-csrf';
+import wixExpressRequireHttps from '@wix/wix-express-require-https';
 
 module.exports = (app, context) => {
   const config = context.config.load('test-gen');

--- a/generated-example/src/test-setup.js
+++ b/generated-example/src/test-setup.js
@@ -1,5 +1,5 @@
 import axios from 'axios';
-import { wixAxiosConfig } from 'wix-axios-config';
+import { wixAxiosConfig } from '@wix/wix-axios-config';
 import { baseURL } from '../test/test-common';
 
 wixAxiosConfig(axios, { baseURL });

--- a/generated-example/test/environment.js
+++ b/generated-example/test/environment.js
@@ -1,5 +1,5 @@
-import testkit from 'wix-bootstrap-testkit';
-import configEmitter from 'wix-config-emitter';
+import testkit from '@wix/wix-bootstrap-testkit';
+import configEmitter from '@wix/wix-config-emitter';
 
 export const app = bootstrapServer();
 

--- a/generated-example/test/it/server.spec.js
+++ b/generated-example/test/it/server.spec.js
@@ -1,7 +1,7 @@
 import axios from 'axios';
 import adapter from 'axios/lib/adapters/http';
 import { beforeAndAfter, app } from '../environment';
-import { wixAxiosInstanceConfig } from 'wix-axios-config';
+import { wixAxiosInstanceConfig } from '@wix/wix-axios-config';
 
 const axiosInstance = wixAxiosInstanceConfig(axios, { adapter });
 


### PR DESCRIPTION
Hi, I'm Nissix, the automated PR bot!

Wix is moving its internal packages to the @wix scope (but still in the internal registry). Publishing new unscoped internal packages is no longer allowed, and all existing packages are moving to @wix. This means changing package names, and also all usages of those packages to their @wix scope version.

This PR is an automatic codemod that moves all of your packages to @wix scope, and changes any usages (`pacakge.json`, imports, requires, etc..) to their @wix version.

| :bangbang: | This codemod is best-effort! Meaning it may not have found and fixed all usages, but it did change your package.jsons. So go over the changes carefully and test this version carefully  |
| :--------: | :----------------------------------------------------------------------------------------------------- |

If you want to know why we don't support publishing unscoped to the internal registry, check out this article on [Dependency Confusion](https://medium.com/@alex.birsan/dependency-confusion-4a5d60fec610)

If you are unsure, need help or have questions, reach us at #wix-scope-migration

Error Log:
npx: installed 234 in 5.826s



Output Log:
Migrating package "wkit" in .


## Migration from non scope to @wix/scoped packages
> /tmp/e4a3fb77d88a6fb1390342316c48043b

#### rename package.json dependencies/dev/bundled/peer/optional, jest & eslintConfig
```
generated-example/package.json
```

#### replace import/require in js/ts files
```
generated-example/index.js
generated-example/src/client.js
generated-example/src/server.js
generated-example/src/test-setup.js
generated-example/test/environment.js
generated-example/test/it/server.spec.js
```

